### PR TITLE
Fix `newObjectOnce` and `getPriceMult` bugs

### DIFF
--- a/eimo/hooks/character_screen.nut
+++ b/eimo/hooks/character_screen.nut
@@ -135,9 +135,16 @@
 
 	o.eimo_getRepairData <- function()
 	{
-		::EIMO.RepairBrothersData.SelectedBrotherPrice = this.eimo_getRepairPriceBrother(this.eimo_getSelectedBrother());
-		::EIMO.RepairBrothersData.CompanyPrice = this.eimo_getRepairPriceCompany();
+		if (this.m.eimo_RepairTown == null) {
+			::EIMO.RepairBrothersData.CanRepairNearby = false;
+		} else {
+			local bro = this.eimo_getSelectedBrother();
+			::EIMO.RepairBrothersData.SelectedBrotherPrice = bro
+				? this.eimo_getRepairPriceBrother(bro) : 0;
+			::EIMO.RepairBrothersData.CompanyPrice = this.eimo_getRepairPriceCompany();
+		}
 
+		// ::std.Debug.log("eimo: RepairBrothersData", ::EIMO.RepairBrothersData);
 		::EIMO.Mod.Debug.printLog(format("SelectedBrotherPrice: %s, CompanyPrice: %s", ::EIMO.RepairBrothersData.SelectedBrotherPrice.tostring(), ::EIMO.RepairBrothersData.CompanyPrice.tostring()));
 
 		return ::EIMO.RepairBrothersData;

--- a/eimo/hooks/character_screen.nut
+++ b/eimo/hooks/character_screen.nut
@@ -1,4 +1,4 @@
-::mods_hookNewObjectOnce("ui/screens/character/character_screen", function(o)
+::mods_hookNewObject("ui/screens/character/character_screen", function(o)
 {
 	o.m.eimo_RepairTown <- null;
 	o.m.eimo_SelectedBrother <- null;

--- a/eimo/hooks/data_helper.nut
+++ b/eimo/hooks/data_helper.nut
@@ -1,4 +1,4 @@
-::mods_hookNewObjectOnce("ui/global/data_helper", function ( o )
+::mods_hookNewObject("ui/global/data_helper", function ( o )
 {
 	local convertItemToUIData = o.convertItemToUIData;
 	o.convertItemToUIData = function ( _item, _forceSmallIcon, _owner = null )

--- a/ui/mods/eimo/character_screen_right_panel_header_module.js
+++ b/ui/mods/eimo/character_screen_right_panel_header_module.js
@@ -144,6 +144,7 @@ CharacterScreenRightPanelHeaderModule.prototype.EIMOupdateRepairButtons = functi
 	{
 		this.mDataSource.EIMOgetRepairData(function(data)
 		{
+			self.mEIMO.CanRepair = data.CanRepairNearby;
 			self.EIMOrepairBrotherButtonState(data.SelectedBrotherPrice != 0);
 			self.EIMOrepairCompanyButtonState(data.CompanyPrice != 0);
 		});


### PR DESCRIPTION
From [discord](https://discord.com/channels/1006908336991645757/1172125017471975454/1173015049133097101):

There are two bugs there:

1. The js "undefined is not an object (while evaluating `_data.EIMO.legends`). This happens after you load-save-load the game and `::mods_hookNewObjectOnce("ui/screens/character/character_screen", ...)` stops working. After second time `character_screen.queryData()` goes vanilla, i.e. not patched, and so doesn't add `EIMO` key, which makes `_data.EIMO` undefined and `_data.EIMO.legends` trigger the error.

2. The `getPriceMult` one. Happens from the fragility of separating `CharacterScreenRightPanelHeaderModule.EIMO.CanRepair` flag from calling `EIMOgetRepairData -> EIMOnotifyBackendgetRepairData -> eimo_getRepairData`. Sometimes it somehow becomes that flag is true but you left the city and `character_screen.m.eimo_RepairTown` is already set to null, might be some race, the extra effect of the bug above or some other situation, not sure. The fix is to remove the flag, make `.eimo_getRepairData()` not bork when there is no repair town but signalize about that somehow, either include `canRepair` flag in its result or put null/0 for `.SelectedBrotherPrice` and `.CompanyPrice`, then update the button based on that.